### PR TITLE
Demo CI with update comment (instead of multiple comments)

### DIFF
--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -74,8 +74,7 @@ jobs:
 
                   let commentBody;
                   if (linterExitCode == 1) {
-                    commentBody = `
-                    # dbt-opiner Linter Results
+                    commentBody = WATERMARK + `
 
                     ## ❌ Some files failed linting
 
@@ -84,8 +83,7 @@ jobs:
                     `;
                   } 
                   else if (linterOutput.includes('WARNING')) {
-                    commentBody = `
-                    # dbt-opiner Linter Results
+                    commentBody = WATERMARK + `
 
                     ## ⚠️ These files can be improved
 
@@ -94,8 +92,7 @@ jobs:
                     `;
                   }
                   else {
-                    commentBody = `
-                    # dbt-opiner Linter Results
+                    commentBody = WATERMARK + `
                     ## ✅ All looks good!
                     `;
                   };
@@ -104,7 +101,7 @@ jobs:
                       owner: context.repo.owner,
                       repo: context.repo.repo
                   });
-                  core.info(comments);
+                  core.info(JSON.stringify(comments, null, 2));
                   const comment = comments.find((c) => c.body.startsWith());
                   if (comment) {
                     core.info('Previous comment found, updating it');

--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -66,7 +66,7 @@ jobs:
                 script: |
                   const linterOutput = `${{ steps.dbt-opiner-lint.outputs.linter_output }}`;
                   const linterExitCode = ${{ steps.dbt-opiner-lint.outputs.linter_exitcode }};
-                  const WATERMARK = `## dbt-opiner Linter Results`;
+                  const WATERMARK = `# dbt-opiner Linter Results`;
                   // Replace with icons
                   const colorizedOutput = linterOutput
                     .replace(/WARNING/g, '⚠️')
@@ -106,6 +106,7 @@ jobs:
                   });
                   const comment = comments.find((c) => c.body.startsWith());
                   if (comment) {
+                    core.info('Previous comment found, updating it');
                     await github.rest.issues.updateComment({
                       comment_id: comment.id,  
                       owner: context.repo.owner,
@@ -113,6 +114,7 @@ jobs:
                       body: commentBody
                     });
                   } else {
+                    core.info('No previous comment found, creating a new one');
                     await github.rest.issues.createComment({
                       issue_number: context.issue.number,
                       owner: context.repo.owner,

--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -101,8 +101,7 @@ jobs:
                       owner: context.repo.owner,
                       repo: context.repo.repo
                   });
-                  core.info(JSON.stringify(comments, null, 2));
-                  const comment = comments.find((c) => c.body.startsWith());
+                  const comment = comments.find((c) => c.body.startsWith(WATERMARK));
                   if (comment) {
                     core.info('Previous comment found, updating it');
                     await github.rest.issues.updateComment({

--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -100,26 +100,26 @@ jobs:
                     ## ✅ All looks good!
                     `;
                   };
-                  const { data: comments } = await octokit.issues.listComments({
-                  repo,
-                  owner,
-                  issue_number,
+                  const { data: comments } = await github.rest.issues.listComments({
+                      issue_number: context.issue.number,
+                      owner: context.repo.owner,
+                      repo: context.repo.repo
                   });
                   const comment = comments.find((c) => c.body.startsWith());
                   if (comment) {
-                    core.info('Found previous comment, updating');
-                    await octokit.issues.updateComment({
-                      repo,
-                      owner,
-                      comment_id: comment.id,
-                      commentBody,
+                    core.info('Previous comment found, updating it');
+                    await github.rest.issues.updateComment({
+                      comment_id: comment.id,  
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      body: commentBody
                     });
                   } else {
                     core.info('No previous comment found, creating a new one');
-                    await octokit.issues.createComment({
-                      repo,
-                      owner,
-                      issue_number,
-                      commentBody,
+                    await github.rest.issues.createComment({
+                      issue_number: context.issue.number,
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      body: commentBody
                     });
                   };

--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -104,7 +104,7 @@ jobs:
                       owner: context.repo.owner,
                       repo: context.repo.repo
                   });
-                  core.info(comments.find(c));
+                  core.info(comments);
                   const comment = comments.find((c) => c.body.startsWith());
                   if (comment) {
                     core.info('Previous comment found, updating it');

--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -66,7 +66,7 @@ jobs:
                 script: |
                   const linterOutput = `${{ steps.dbt-opiner-lint.outputs.linter_output }}`;
                   const linterExitCode = ${{ steps.dbt-opiner-lint.outputs.linter_exitcode }};
-                  
+                  const WATERMARK = 'dbt-opiner Linter Results';
                   // Replace with icons
                   const colorizedOutput = linterOutput
                     .replace(/WARNING/g, '⚠️')
@@ -99,10 +99,26 @@ jobs:
                     ## ✅ All looks good!
                     `;
                   };
-                  github.rest.issues.createComment({
-                    issue_number: context.issue.number,
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    body: commentBody
+                  const { data: comments } = await octokit.issues.listComments({
+                  repo,
+                  owner,
+                  issue_number,
                   });
-             
+                  const comment = comments.find((c) => c.body.startsWith());
+                  if (comment) {
+                    core.info('Found previous comment, updating');
+                    await octokit.issues.updateComment({
+                      repo,
+                      owner,
+                      comment_id: comment.id,
+                      commentBody,
+                    });
+                  } else {
+                    core.info('No previous comment found, creating a new one');
+                    await octokit.issues.createComment({
+                      repo,
+                      owner,
+                      issue_number,
+                      commentBody,
+                    });
+                  };

--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -64,6 +64,8 @@ jobs:
               uses: actions/github-script@v6
               with:
                 script: |
+                  const github = require('@actions/github');
+                  const octokit = github.getOctokit(token);
                   const linterOutput = `${{ steps.dbt-opiner-lint.outputs.linter_output }}`;
                   const linterExitCode = ${{ steps.dbt-opiner-lint.outputs.linter_exitcode }};
                   const WATERMARK = 'dbt-opiner Linter Results';

--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -64,10 +64,9 @@ jobs:
               uses: actions/github-script@v6
               with:
                 script: |
-                  const octokit = github.getOctokit(token);
                   const linterOutput = `${{ steps.dbt-opiner-lint.outputs.linter_output }}`;
                   const linterExitCode = ${{ steps.dbt-opiner-lint.outputs.linter_exitcode }};
-                  const WATERMARK = 'dbt-opiner Linter Results';
+                  const WATERMARK = `## dbt-opiner Linter Results`;
                   // Replace with icons
                   const colorizedOutput = linterOutput
                     .replace(/WARNING/g, '⚠️')
@@ -107,7 +106,6 @@ jobs:
                   });
                   const comment = comments.find((c) => c.body.startsWith());
                   if (comment) {
-                    core.info('Previous comment found, updating it');
                     await github.rest.issues.updateComment({
                       comment_id: comment.id,  
                       owner: context.repo.owner,
@@ -115,7 +113,6 @@ jobs:
                       body: commentBody
                     });
                   } else {
-                    core.info('No previous comment found, creating a new one');
                     await github.rest.issues.createComment({
                       issue_number: context.issue.number,
                       owner: context.repo.owner,

--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -64,7 +64,6 @@ jobs:
               uses: actions/github-script@v6
               with:
                 script: |
-                  const github = require('@actions/github');
                   const octokit = github.getOctokit(token);
                   const linterOutput = `${{ steps.dbt-opiner-lint.outputs.linter_output }}`;
                   const linterExitCode = ${{ steps.dbt-opiner-lint.outputs.linter_exitcode }};

--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -104,6 +104,7 @@ jobs:
                       owner: context.repo.owner,
                       repo: context.repo.repo
                   });
+                  core.info(comments.find(c));
                   const comment = comments.find((c) => c.body.startsWith());
                   if (comment) {
                     core.info('Previous comment found, updating it');

--- a/customers/models/dimensions/_dim_customers__models.yml
+++ b/customers/models/dimensions/_dim_customers__models.yml
@@ -11,3 +11,9 @@ models:
         data_tests:
           - unique
           - not_null
+      - name: first_name
+        description: >
+          First name of the customer
+      - name: last_name
+        description: >
+          Last name of the customer

--- a/customers/models/dimensions/_dim_customers__models.yml
+++ b/customers/models/dimensions/_dim_customers__models.yml
@@ -1,0 +1,13 @@
+version: 2
+
+models:
+  - name: dim_customers
+    description: >
+     Customer dimension table
+    columns:
+      - name: customer_id
+        description: >
+          Unique identifier for the customer
+        data_tests:
+          - unique
+          - not_null

--- a/customers/models/dimensions/_dim_customers__models.yml
+++ b/customers/models/dimensions/_dim_customers__models.yml
@@ -3,7 +3,8 @@ version: 2
 models:
   - name: dim_customers
     description: >
-     Customer dimension table
+     Summary: Customer dimension table
+     Granularity: one customer per row
     columns:
       - name: customer_id
         description: >

--- a/customers/models/dimensions/dim_customers.sql
+++ b/customers/models/dimensions/dim_customers.sql
@@ -1,0 +1,3 @@
+with customers as (select customer_id, first_name, last_name from {{ ref("stg_customers") }})
+select *
+from customers


### PR DESCRIPTION
## Demo CI run for dbt opiner
This PR shows how to run [dbt-opiner](https://github.com/dbt-opiner/dbt-opiner) in CI checks and updating the comment with the linter results instead of adding a new comment every time (like [here](https://github.com/dbt-opiner/demo-multi-dbt-project/pull/2))
Check the changed files for the workflow code.

### First commit
Introduces a bad model with failing linting.

### Second commit
Fixes the critical errors. **You will see that the comment was updated and only the warnings are left**

