### PR TITLE
Demo CI with update comment (instead of multiple comments)

### DIFF
--- a/.github/workflows/run_dbt_opiner.yaml
+++ b/.github/workflows/run_dbt_opiner.yaml
@@ -66,7 +66,7 @@ jobs:
                 script: |
                   const linterOutput = `${{ steps.dbt-opiner-lint.outputs.linter_output }}`;
                   const linterExitCode = ${{ steps.dbt-opiner-lint.outputs.linter_exitcode }};
-                  
+                  const WATERMARK = `# dbt-opiner Linter Results`;
                   // Replace with icons
                   const colorizedOutput = linterOutput
                     .replace(/WARNING/g, '⚠️')
@@ -74,8 +74,7 @@ jobs:
 
                   let commentBody;
                   if (linterExitCode == 1) {
-                    commentBody = `
-                    # dbt-opiner Linter Results
+                    commentBody = WATERMARK + `
 
                     ## ❌ Some files failed linting
 
@@ -84,8 +83,7 @@ jobs:
                     `;
                   } 
                   else if (linterOutput.includes('WARNING')) {
-                    commentBody = `
-                    # dbt-opiner Linter Results
+                    commentBody = WATERMARK + `
 
                     ## ⚠️ These files can be improved
 
@@ -94,15 +92,30 @@ jobs:
                     `;
                   }
                   else {
-                    commentBody = `
-                    # dbt-opiner Linter Results
+                    commentBody = WATERMARK + `
                     ## ✅ All looks good!
                     `;
                   };
-                  github.rest.issues.createComment({
-                    issue_number: context.issue.number,
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    body: commentBody
+                  const { data: comments } = await github.rest.issues.listComments({
+                      issue_number: context.issue.number,
+                      owner: context.repo.owner,
+                      repo: context.repo.repo
                   });
-             
+                  const comment = comments.find((c) => c.body.startsWith(WATERMARK));
+                  if (comment) {
+                    core.info('Previous comment found, updating it');
+                    await github.rest.issues.updateComment({
+                      comment_id: comment.id,  
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      body: commentBody
+                    });
+                  } else {
+                    core.info('No previous comment found, creating a new one');
+                    await github.rest.issues.createComment({
+                      issue_number: context.issue.number,
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      body: commentBody
+                    });
+                  };

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/dbt-opiner/dbt-opiner
-    rev: 3e6d992
+    rev: fb7c053
     hooks:
       - id: dbt-opiner-lint
-        args: [-f]
+        args: ["--force-compile", "-f"]
         additional_dependencies: [dbt-duckdb == 1.8.2]
 
   - repo: https://github.com/tconbeer/sqlfmt

--- a/customers/models/dimensions/dim_customers/_dim_customers__models.yml
+++ b/customers/models/dimensions/dim_customers/_dim_customers__models.yml
@@ -2,8 +2,14 @@ models:
   - name: dim_customers
     description: >
      Summary: Customer dimension table
-     
+     Granularity: one customer per row
     columns:
+      - name: customer_id
+        description: >
+          Unique identifier for the customer
+        data_tests:
+          - unique
+          - not_null
       - name: first_name
         description: >
           First name of the customer

--- a/customers/models/dimensions/dim_customers/_dim_customers__models.yml
+++ b/customers/models/dimensions/dim_customers/_dim_customers__models.yml
@@ -1,0 +1,12 @@
+models:
+  - name: dim_customers
+    description: >
+     Summary: Customer dimension table
+     
+    columns:
+      - name: first_name
+        description: >
+          First name of the customer
+      - name: last_name
+        description: >
+          Last name of the customer

--- a/customers/models/dimensions/dim_customers/dim_customers.sql
+++ b/customers/models/dimensions/dim_customers/dim_customers.sql
@@ -1,0 +1,1 @@
+with customers as (select * from {{ ref("stg_customers") }}) select * from customers

--- a/customers/models/dimensions/dim_customers/dim_customers.sql
+++ b/customers/models/dimensions/dim_customers/dim_customers.sql
@@ -1,1 +1,3 @@
-with customers as (select * from {{ ref("stg_customers") }}) select * from customers
+with customers as (select customer_id, first_name, last_name from {{ ref("stg_customers") }})
+select *
+from customers


### PR DESCRIPTION
## Demo CI run for dbt opiner
This PR shows how to run [dbt-opiner](https://github.com/dbt-opiner/dbt-opiner) in CI checks and updating the comment with the linter results instead of adding a new comment every time (like [here](https://github.com/dbt-opiner/demo-multi-dbt-project/pull/2)). Check the workflow code [here](https://github.com/dbt-opiner/demo-multi-dbt-project/blob/main/.github/workflows/run_dbt_opiner_single_comment.yaml).

### First commit
Introduces a bad model with failing linting.

### Second commit
Fixes the critical errors. **You will see that the comment was updated and only the warnings are left**

